### PR TITLE
Price order change & design updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ The markup has been rearranged, and some classes have been removed.
 -				<img class="o-subs-card__copy-image" src='/demos/src/demo-placeholder.png' alt='photo of FT subscription options'>
 				<div class="o-subs-card__charge">
 -					<span class="o-subs-card__charge__value">£XX.XX</span> per week
-					<button class="o-subs-card__select-button">Select</button>
 +					<div class="o-subs-card__charge__value">£XX.XX per week </div>
+					<button class="o-subs-card__select-button">Select</button>
 				</div>
 			</div>
 -			<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -4,8 +4,8 @@
 			<div class="o-subs-card__copy-title">Digital Trial</div>
 			<div class="o-subs-card__copy-pitch">Not sure which package to choose? Try full access for 4 weeks</div>
 			<div class="o-subs-card__charge">
-				<button class="o-subs-card__select-button">Select</button>
 				<div class="o-subs-card__charge__value">£XX.XX per week</div>
+				<button class="o-subs-card__select-button">Select</button>
 			</div>
 		</div>
 		<div class="o-subs-card__expander">
@@ -26,8 +26,8 @@
 			<div class="o-subs-card__copy-title">Standard Digital</div>
 			<div class="o-subs-card__copy-pitch">Be informed with the essential news and opinion</div>
 			<div class="o-subs-card__charge">
-				<button class="o-subs-card__select-button">Select</button>
 				<div class="o-subs-card__charge__value">£XX.XX per week</div>
+				<button class="o-subs-card__select-button">Select</button>
 			</div>
 		</div>
 		<div class="o-subs-card__expander">
@@ -49,8 +49,8 @@
 			<div class="o-subs-card__copy-title">Standard Digital</div>
 			<div class="o-subs-card__copy-pitch">Be informed with the essential news and opinion</div>
 			<div class="o-subs-card__charge">
-				<button class="o-subs-card__select-button">Select</button>
 				<div class="o-subs-card__charge__value">£XX.XX per week</div>
+				<button class="o-subs-card__select-button">Select</button>
 			</div>
 		</div>
 		<div class="o-subs-card__expander">
@@ -69,8 +69,8 @@
 			<div class="o-subs-card__copy-title">Get the FT for your team or business</div>
 			<div class="o-subs-card__copy-pitch">Access on any device and volume discounts</div>
 			<div class="o-subs-card__charge">
-				<button class="o-subs-card__select-button">Enquire about Group subscriptions</button>
 				<div class="o-subs-card__charge__value">Pay based on use</div>
+				<button class="o-subs-card__select-button">Enquire about Group subscriptions</button>
 			</div>
 		</div>
 		<div class="o-subs-card__expander">

--- a/origami.json
+++ b/origami.json
@@ -6,8 +6,8 @@
 	"origamiVersion": 1,
 	"support": "https://github.com/Financial-Times/o-subs-card/issues",
 	"supportContact": {
-		"email": "origami.support@ft.com",
-		"slack": "financialtimes/ft-origami"
+		"email": "next.conversion@ft.com",
+		"slack": "financialtimes/next-conversion-dev"
 	},
 	"supportStatus": "active",
 	"browserFeatures": {},

--- a/src/js/subsCard.js
+++ b/src/js/subsCard.js
@@ -1,10 +1,21 @@
 const oExpander = require('o-expander');
 
+let tallestTopHeight = 0;
+
 class SubsCard {
 
 	constructor (rootEl) {
 		this.rootEl = rootEl;
 		this.setExpanders();
+		this.checkTallest();
+	}
+
+	checkTallest() {
+		const top = this.rootEl.querySelector('.o-subs-card__top');
+
+		if (top && top.clientHeight > tallestTopHeight) {
+			tallestTopHeight = top.clientHeight;
+		}
 	}
 
 	setExpanders() {
@@ -33,7 +44,21 @@ class SubsCard {
 		if (rootEl instanceof HTMLElement && rootEl.matches('[data-o-component=o-subs-card]')) {
 			return new SubsCard(rootEl);
 		}
-		return Array.from(rootEl.querySelectorAll('[data-o-component="o-subs-card"]'), rootEl => new SubsCard(rootEl));
+		let cards = Array.from(rootEl.querySelectorAll('[data-o-component="o-subs-card"]'), rootEl => new SubsCard(rootEl));
+
+		if (cards.length > 1) {
+			SubsCard.matchHeights(cards);
+		}
+
+		return cards;
+	}
+
+	static matchHeights(cards) {
+		for (let i = 0; i < cards.length; i++) {
+			let cardTop = cards[i].rootEl.querySelector('.o-subs-card__top');
+
+			cardTop.style.flex = `0 1 ${tallestTopHeight}px`;
+		}
 	}
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -35,7 +35,7 @@
 
 	.o-subs-card__copy-pitch {
 		@include oTypographySans(0);
-		@include oTypographyPadding($bottom: 8);
+		@include oTypographyPadding($bottom: 3);
 
 		display: inline-block;
 		text-align: center;
@@ -44,6 +44,10 @@
 	}
 
 	.o-subs-card__charge {
+		@include oTypographyPadding($bottom: 4);
+	}
+
+	.o-subs-card__charge__value {
 		@include oTypographyPadding($bottom: 2);
 	}
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -8,6 +8,7 @@
 
 	// https://github.com/philipwalton/flexbugs#flexbug-17 (for suport in ie 9/10)
 	@include oGridRespondTo(L) {
+		// 12px = the combined 6px padding either side.
 		flex: 0 1 calc(25% - 12px);
 		min-width: 0;
 	}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -8,7 +8,7 @@
 
 	// https://github.com/philipwalton/flexbugs#flexbug-17 (for suport in ie 9/10)
 	@include oGridRespondTo(L) {
-		flex: 0 1 25%;
+		flex: 0 1 calc(25% - 12px);
 		min-width: 0;
 	}
 
@@ -139,10 +139,6 @@
 		display: table-cell; //ie 9
 		display: flex; //sass-lint:disable-line no-duplicate-properties
 		flex-direction: column;
-	}
-
-	.o-subs-card__top {
-		flex: 1 0 auto;
 	}
 
 	.o-subs-card__charge {

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -19,7 +19,6 @@ function insert(html) {
 	sandboxEl.innerHTML = html;
 }
 
-
 function htmlCode () {
 	const html = `<div>
 		<h1>Basic Demo</h1>
@@ -36,7 +35,36 @@ function htmlCode () {
 	insert(html);
 }
 
+function htmlCodeMulti () {
+	const html = `<div>
+		<h1>Basic Demo</h1>
+		<div class="o-subs-card__container">
+			<div class="o-subs-card" data-o-component="o-subs-card">
+				<div class="o-subs-card__top"></div>
+				<div class="o-subs-card__expander">
+					<div class="o-subs-card__copy-details">
+						Some content
+					</div>
+					<div class="o-subs-card__read-more"></div>
+				</div>
+			</div>
+			<div class="o-subs-card" data-o-component="o-subs-card">
+				<div class="o-subs-card__top"></div>
+				<div class="o-subs-card__expander">
+					<div class="o-subs-card__copy-details">
+						Some content
+					</div>
+					<div class="o-subs-card__read-more"></div>
+				</div>
+			</div>
+		</div>
+	</div>
+	`;
+	insert(html);
+}
+
 export {
+	htmlCodeMulti,
 	htmlCode,
 	reset
 };

--- a/test/subsCard.test.js
+++ b/test/subsCard.test.js
@@ -49,4 +49,27 @@ describe("SubsCard", () => {
 			proclaim.equal(subsCard instanceof SubsCard, true);
 		});
 	});
+
+	describe('multiple components', () => {
+
+		beforeEach(() => {
+			fixtures.htmlCodeMulti();
+		});
+
+		afterEach(() => {
+			fixtures.reset();
+		});
+
+		it('will all have matching top height', () => {
+			const matchHeightsSpy = sinon.spy(SubsCard, 'matchHeights');
+
+			console.log(matchHeightsSpy);
+
+			SubsCard.init();
+
+			proclaim.equal(matchHeightsSpy.called, true);
+		});
+
+	});
+
 });


### PR DESCRIPTION
The height of the "top" bit of the cards needs to be the same when there are multiple of them next to each other. There isn't really a way to do it in a way that still supports IE9 (no css grid support) that doesn't involve making the markup really weird for the use cases where only a single card is used.

Happy to get feedback on any better ideas as this was a kind of "we have no other choice" approach.

![ft-o-subs-card](https://user-images.githubusercontent.com/708296/38798990-1fdf769a-415b-11e8-921e-50ae0ef740fc.gif)