### PR TITLE
update primary button to standard format

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -49,11 +49,7 @@
 	}
 
 	.o-subs-card__select-button {
-		@include oButtons($size: 'big', $theme: (
-			accent: oColorsGetUseCase(o-subs-card-button, background),
-			background: 'white',
-			colorizer: 'primary'
-		));
+		@include oButtons($size: 'big', $theme: 'primary');
 		@include oTypographyMargin($bottom: 1);
 		width: 100%;
 	}

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -34,7 +34,11 @@
 	}
 
 	.o-subs-card__select-button {
-		@include oButtons($size: 'big', $theme: 'primary');
+		@include oButtonsTheme($theme: (
+			background: "white",
+			accent: oColorsGetUseCase(o-subs-card-discount, background),
+			colorizer: 'primary'
+		));
 	}
 
 	.o-subs-card__charge__value {

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -34,11 +34,7 @@
 	}
 
 	.o-subs-card__select-button {
-		@include oButtonsTheme($theme: (
-			background: "white",
-			accent: oColorsGetUseCase(o-subs-card-discount, background),
-			colorizer: 'primary'
-		));
+		@include oButtons($size: 'big', $theme: 'primary');
 	}
 
 	.o-subs-card__charge__value {


### PR DESCRIPTION
Update the primary button to use the `primary` theme rather than custom styling - as requested by James Drayson.

This affects the `hover` state, which goes from this:

![image](https://user-images.githubusercontent.com/17846996/42882059-5c55cbf0-8a90-11e8-830c-8dd106e77741.png)

to this:

![image](https://user-images.githubusercontent.com/17846996/42882073-60cb12f8-8a90-11e8-8fcb-199429f0dcb3.png)
