### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import { SubsCard } from './../../main.js';
+import { SubsCard } from './../../main.js.js';
 
 document.addEventListener('DOMContentLoaded', function() {
 	const cards = SubsCard.init();

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import { SubsCard } from './../../main.js.js';
+import { SubsCard } from './../../main.js';
 
 document.addEventListener('DOMContentLoaded', function() {
 	const cards = SubsCard.init();

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import {SubsCard} from './src/js/subsCard';
+import {SubsCard} from './src/js/subsCard.js';
 
 const constructAll = function() {
 	SubsCard.init();

--- a/test/subsCard.test.js
+++ b/test/subsCard.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import {SubsCard} from './../main';
+import {SubsCard} from './../main.js';
 
 describe("SubsCard", () => {
 	it('is defined', () => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing