### PR TITLE
Accessibility review changes for the component 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,6 @@
 node_modules
 demos/local
 build/
-demos/*.html
 .eslintrc.cjs
 .github
 .gitignore

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,23 @@
 # Migration Guide
 
+## Migrating from v5 to v6
+
+Component HTML markup section used to expand for reading more/less info about the card is updated. It used to trigger by the div and now it is updated to Button.
+
+The label of it has added dynamic text to it for screen reader users based on the title of the card `Read more about Print`. It is added by this `function this.setExpanders() in subCard.js`. Below is the difference after function this.setExpanders() adds span element for screen reader users.
+
+```diff
+- <div class='o-subs-card__read-more'>Read more</div>
++ <button class="o-subs-card__read-more">Read More <span class="o-subs-card-visually-hidden">about Standard Digital</span></button>
+```
+
+A new CSS class has been added to have visually hidden elements but to be used for screen reader users.
+```
+.o-subs-card-visually-hidden {
+    @include oNormaliseVisuallyHidden;
+}
+```
+
 ## Migrating from v4 to v5
 
 The mixin `oSubsCard` has been renamed to `oSubsCardBase`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -83,7 +83,7 @@ The markup has been rearranged, and some classes have been removed.
 			</div>
 -			<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
--		 		<button class='o-subs-card__read-more'></button>
+-		 		<div class='o-subs-card__read-more'></div>
 					<div class="o-subs-card__copy-details">
 						<ul class="o-subs-card__copy-benefits">
 							<li>...</li>

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -83,13 +83,13 @@ The markup has been rearranged, and some classes have been removed.
 			</div>
 -			<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
--		 		<div class='o-subs-card__read-more'>Read more</div>
+-		 		<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<ul class="o-subs-card__copy-benefits">
 							<li>...</li>
 						</ul>
 					</div>
-+					<div class='o-subs-card__read-more'>Read more</div>
++					<button class='o-subs-card__read-more'></button>
 				</div>
 		</div>
 + </div>

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,15 +2,15 @@
 
 ## Migrating from v5 to v6
 
-Component HTML markup section used to expand for reading more/less info about the card is updated. It used to trigger by the div and now it is updated to Button.
+The "more/less" toggle has been updated to use a `button` element instead of a `div` to improve keyboard accessibility.
 
-The label of it has added dynamic text to it for screen reader users based on the title of the card `Read more about Print`. It is added by this `function this.setExpanders() in subCard.js`. Below is the difference after function this.setExpanders() adds span element for screen reader users.
-
+To upgrade, replace the "read more" `div` tag with a `button` tag in your markup.
 ```diff
 - <div class='o-subs-card__read-more'>Read more</div>
-+ <button class="o-subs-card__read-more">Read More <span class="o-subs-card-visually-hidden">about Standard Digital</span></button>
++ <button class='o-subs-card__read-more'></button>
 ```
 
+The button copy is added dynamically, and now includes hidden text to provide screen reader users more context based on the title of the card e.g. `Read more about Print`.
 A new CSS class has been added to have visually hidden elements but to be used for screen reader users.
 ```
 .o-subs-card-visually-hidden {

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The subs card will expand to fill the width of its containing element, so you wi
 					<li>...</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 </div>

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ This will instantiate all subs-cards within the document. Alternatively you can 
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 5 | N/A | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+✨ active | 6 | N/A | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+⚠ maintained | 5 | 5.0.1 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
 ⚠ maintained | 4 | 4.1 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 ╳ deprecated | 3 | 3.1 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 ╳ deprecated | 2 | 2.4 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -18,7 +18,7 @@
 					<li>Brexit Briefing - your essential guide to the impact of the UK-EU split</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 	<div class="o-subs-card" data-o-component="o-subs-card">
@@ -40,7 +40,7 @@
 					<li>Brexit Briefing - your essential guide to the impact of the UK-EU split</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 	<div class="o-subs-card o-subs-card--discount" data-o-component="o-subs-card">
@@ -61,7 +61,7 @@
 					<li>FastFT - market-moving news and views, 24 hours a day</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 	<div class="o-subs-card o-subs-card--b2b" data-o-component="o-subs-card">
@@ -81,7 +81,7 @@
 					<li>And much more</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 </div>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -12,7 +12,7 @@
 				</div>
 				<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
-					<div class='o-subs-card__read-more'>Read more</div>
+					<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<ul class="o-subs-card__copy-benefits">
 							<li>Access to FT's award-winning news on desktop, mobile and tablet</li>
@@ -37,7 +37,7 @@
 				</div>
 				<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
-					<div class='o-subs-card__read-more'>Read more</div>
+					<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<div class="o-subs-card__copy-preamble">Standard Digital benefits</div>
 						<ul class="o-subs-card__copy-benefits">
@@ -63,7 +63,7 @@
 				</div>
 				<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
-					<div class='o-subs-card__read-more'>Read more</div>
+					<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<div class="o-subs-card__copy-preamble">Standard Digital benefits, plus</div>
 						<ul class="o-subs-card__copy-benefits">
@@ -89,7 +89,7 @@
 				</div>
 				<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
-					<div class='o-subs-card__read-more'>Read more</div>
+					<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<div class="o-subs-card__copy-preamble">Standard Digital benefits, plus</div>
 						<ul class="o-subs-card__copy-benefits">

--- a/main.js
+++ b/main.js
@@ -7,4 +7,4 @@ const constructAll = function() {
 
 document.addEventListener('o.DOMContentLoaded', constructAll);
 
-export { SubsCard } from './src/js/subsCard';
+export { SubsCard } from './src/js/subsCard.js';

--- a/main.scss
+++ b/main.scss
@@ -4,6 +4,7 @@
 @import "@financial-times/o-typography/main";
 @import "@financial-times/o-expander/main";
 @import "@financial-times/o-spacing/main";
+@import '@financial-times/o-normalise/main';
 
 @import "src/scss/variables";
 @import "src/scss/mixins";

--- a/src/js/subsCard.js
+++ b/src/js/subsCard.js
@@ -24,8 +24,8 @@ class SubsCard {
 		const titleElem = this.rootEl.querySelector('.o-subs-card__copy-title');
 		const opts = {
 			shrinkTo: 'hidden',
-			collapsedToggleText: titleElem ? `Read More <span class="o-subs-card-visually-hidden">about ${titleElem.textContent}</span>` : 'Read More',
-			expandedToggleText: titleElem ? `Read Less <span class="o-subs-card-visually-hidden">about ${titleElem.textContent}</span>` : 'Read Less',
+			collapsedToggleText: titleElem ? `Read more <span class="o-subs-card-visually-hidden">about ${titleElem.textContent}</span>` : 'Read more',
+			expandedToggleText: titleElem ? `Read less <span class="o-subs-card-visually-hidden">about ${titleElem.textContent}</span>` : 'Read less',
 			toggleState: 'all',
 			selectors: {
 				toggle: '.o-subs-card__read-more',

--- a/src/js/subsCard.js
+++ b/src/js/subsCard.js
@@ -24,8 +24,8 @@ class SubsCard {
 		const titleElem = this.rootEl.querySelector('.o-subs-card__copy-title');
 		const opts = {
 			shrinkTo: 'hidden',
-			collapsedToggleText: titleElem ? `Read More <span class="o-normalise-visually-hidden">about ${title.textContent}</span>` : 'Read More',
-			expandedToggleText: titleElem ? `Read Less <span class="o-normalise-visually-hidden">about ${title.textContent}</span>` : 'Read Less',
+			collapsedToggleText: titleElem ? `Read More <span class="o-normalise-visually-hidden">about ${titleElem.textContent}</span>` : 'Read More',
+			expandedToggleText: titleElem ? `Read Less <span class="o-normalise-visually-hidden">about ${titleElem.textContent}</span>` : 'Read Less',
 			toggleState: 'all',
 			selectors: {
 				toggle: '.o-subs-card__read-more',

--- a/src/js/subsCard.js
+++ b/src/js/subsCard.js
@@ -19,7 +19,7 @@ class SubsCard {
 		}
 	}
 
-	setExpanders(rootEl) {
+	setExpanders() {
 		const expander = this.rootEl.querySelector('.o-subs-card__expander');
 		const title = this.rootEl.querySelector('.o-subs-card__copy-title').textContent;
 		const opts = {

--- a/src/js/subsCard.js
+++ b/src/js/subsCard.js
@@ -24,8 +24,8 @@ class SubsCard {
 		const titleElem = this.rootEl.querySelector('.o-subs-card__copy-title');
 		const opts = {
 			shrinkTo: 'hidden',
-			collapsedToggleText: titleElem ? `Read More <span class="o-normalise-visually-hidden">about ${titleElem.textContent}</span>` : 'Read More',
-			expandedToggleText: titleElem ? `Read Less <span class="o-normalise-visually-hidden">about ${titleElem.textContent}</span>` : 'Read Less',
+			collapsedToggleText: titleElem ? `Read More <span class="o-subs-card-visually-hidden">about ${titleElem.textContent}</span>` : 'Read More',
+			expandedToggleText: titleElem ? `Read Less <span class="o-subs-card-visually-hidden">about ${titleElem.textContent}</span>` : 'Read Less',
 			toggleState: 'all',
 			selectors: {
 				toggle: '.o-subs-card__read-more',

--- a/src/js/subsCard.js
+++ b/src/js/subsCard.js
@@ -21,11 +21,11 @@ class SubsCard {
 
 	setExpanders() {
 		const expander = this.rootEl.querySelector('.o-subs-card__expander');
-		const title = this.rootEl.querySelector('.o-subs-card__copy-title').textContent;
+		const titleElem = this.rootEl.querySelector('.o-subs-card__copy-title');
 		const opts = {
 			shrinkTo: 'hidden',
-			collapsedToggleText: title ? `Read More <span class="o-normalise-visually-hidden">about ${title}</span>` : 'Read More',
-			expandedToggleText: title ? `Read Less <span class="o-normalise-visually-hidden">about ${title}</span>` : 'Read Less',
+			collapsedToggleText: titleElem ? `Read More <span class="o-normalise-visually-hidden">about ${title.textContent}</span>` : 'Read More',
+			expandedToggleText: titleElem ? `Read Less <span class="o-normalise-visually-hidden">about ${title.textContent}</span>` : 'Read Less',
 			toggleState: 'all',
 			selectors: {
 				toggle: '.o-subs-card__read-more',

--- a/src/js/subsCard.js
+++ b/src/js/subsCard.js
@@ -19,12 +19,13 @@ class SubsCard {
 		}
 	}
 
-	setExpanders() {
+	setExpanders(rootEl) {
 		const expander = this.rootEl.querySelector('.o-subs-card__expander');
+		const title = this.rootEl.querySelector('.o-subs-card__copy-title').textContent;
 		const opts = {
 			shrinkTo: 'hidden',
-			expandedToggleText: 'Read less',
-			collapsedToggleText: 'Read more',
+			collapsedToggleText: title ? `Read More <span class="o-normalise-visually-hidden">about ${title}</span>` : 'Read More',
+			expandedToggleText: title ? `Read Less <span class="o-normalise-visually-hidden">about ${title}</span>` : 'Read Less',
 			toggleState: 'all',
 			selectors: {
 				toggle: '.o-subs-card__read-more',

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -3,6 +3,10 @@
 
 	text-align: center;
 
+	.o-normalise-visually-hidden {
+		@include oNormaliseVisuallyHidden;
+	}
+
 	// https://github.com/philipwalton/flexbugs#flexbug-17 (for suport in ie 9/10)
 	@include oGridRespondTo(L) {
 		// 12px = the combined 6px padding either side.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -3,7 +3,7 @@
 
 	text-align: center;
 
-	.o-normalise-visually-hidden {
+	.o-subs-card-visually-hidden {
 		@include oNormaliseVisuallyHidden;
 	}
 

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -27,7 +27,7 @@ function htmlCode () {
 				<div class="o-subs-card__copy-details">
 					Some content
 				</div>
-				<div class="o-subs-card__read-more"></div>
+				<button class="o-subs-card__read-more"></button>
 			</div>
 		</div>
 	</div>
@@ -45,7 +45,7 @@ function htmlCodeMulti () {
 					<div class="o-subs-card__copy-details">
 						Some content
 					</div>
-					<div class="o-subs-card__read-more"></div>
+					<button class="o-subs-card__read-more"></button>
 				</div>
 			</div>
 			<div class="o-subs-card" data-o-component="o-subs-card">
@@ -54,7 +54,7 @@ function htmlCodeMulti () {
 					<div class="o-subs-card__copy-details">
 						Some content
 					</div>
-					<div class="o-subs-card__read-more"></div>
+					<button class="o-subs-card__read-more"></button>
 				</div>
 			</div>
 		</div>

--- a/test/subsCard.test.js
+++ b/test/subsCard.test.js
@@ -63,8 +63,6 @@ describe("SubsCard", () => {
 		it('will all have matching top height', () => {
 			const matchHeightsSpy = sinon.spy(SubsCard, 'matchHeights');
 
-			console.log(matchHeightsSpy);
-
 			SubsCard.init();
 
 			proclaim.equal(matchHeightsSpy.called, true);


### PR DESCRIPTION
Changes are based on the accessibility report done by a third party and the following tickets in particular:
1. https://financialtimes.atlassian.net/browse/DAC-138
2. https://financialtimes.atlassian.net/browse/DAC-113

2 major changes to the component to have better markup and more accessible to screen reader users:
1. Replacing the div to the button.
2. Changing the text 'Read more/less' to add `about title` in the label for the screen reader users only.

Mac's Voice Over Screenshot attached
<img width="695" alt="read-more-digital-trial-voice-over-mac" src="https://user-images.githubusercontent.com/36263/130602468-072fca2f-1fcd-4619-bf9c-c92d4937baa9.png">
