### PR TITLE
 Release a bower version of v6 for those projects which can not currently migrate away from bower

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,25 @@
 # Migration Guide
 
+## Migrating from v5-bower to v6-bower
+
+Note: These changes have been released in a temporary backport which includes Bower and Origami Build Service v2 support. v6.0.0-bower is not recommended outside a temporary measure for those unable to complete the v4 to v5 migration immediately.
+
+The "more/less" toggle has been updated to use a `button` element instead of a `div` to improve keyboard accessibility.
+
+To upgrade, replace the "read more" `div` tag with a `button` tag in your markup.
+```diff
+- <div class='o-subs-card__read-more'>Read more</div>
++ <button class='o-subs-card__read-more'></button>
+```
+
+The button copy is added dynamically, and now includes hidden text to provide screen reader users more context based on the title of the card e.g. `Read more about Print`.
+A new CSS class has been added to have visually hidden elements but to be used for screen reader users.
+```
+.o-subs-card-visually-hidden {
+    @include oNormaliseVisuallyHidden;
+}
+```
+
 ## Migrating from v4 to v5-bower
 
 Note: These changes have been released in a temporary backport which includes Bower and Origami Build Service v2 support. v5.0.0-bower is not recommended outside a temporary measure for those unable to complete the v4 to v5 migration immediately.
@@ -81,13 +101,13 @@ The markup has been rearranged, and some classes have been removed.
 			</div>
 -			<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
--		 		<div class='o-subs-card__read-more'>Read more</div>
+-		 		<div class='o-subs-card__read-more'></div>
 					<div class="o-subs-card__copy-details">
 						<ul class="o-subs-card__copy-benefits">
 							<li>...</li>
 						</ul>
 					</div>
-+					<div class='o-subs-card__read-more'>Read more</div>
++					<button class='o-subs-card__read-more'></button>
 				</div>
 		</div>
 + </div>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The subs card will expand to fill the width of its containing element, so you wi
 					<li>...</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 </div>
@@ -89,7 +89,8 @@ This will instantiate all subs-cards within the document. Alternatively you can 
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 5 | N/A | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+✨ active | 6 | N/A | [migrate to v6](MIGRATION.md#migrating-from-v5-to-v6) |
+⚠ maintained | 5 | 5.0.1 | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
 ⚠ maintained | 4 | 4.1 | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
 ╳ deprecated | 3 | 3.1 | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 ╳ deprecated | 2 | 2.4 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "o-expander": "^5.0.1",
     "o-grid": "^5.0.0",
     "o-typography": "^6.0.1",
-    "o-spacing": "^2.0.0"
+    "o-spacing": "^2.0.0",
+    "o-normalise": "^2"
   }
 }

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -18,7 +18,7 @@
 					<li>Brexit Briefing - your essential guide to the impact of the UK-EU split</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 	<div class="o-subs-card" data-o-component="o-subs-card">
@@ -40,7 +40,7 @@
 					<li>Brexit Briefing - your essential guide to the impact of the UK-EU split</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 	<div class="o-subs-card o-subs-card--discount" data-o-component="o-subs-card">
@@ -61,7 +61,7 @@
 					<li>FastFT - market-moving news and views, 24 hours a day</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 	<div class="o-subs-card o-subs-card--b2b" data-o-component="o-subs-card">
@@ -81,7 +81,7 @@
 					<li>And much more</li>
 				</ul>
 			</div>
-			<div class='o-subs-card__read-more'>Read more</div>
+			<button class='o-subs-card__read-more'></button>
 		</div>
 	</div>
 </div>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -12,7 +12,7 @@
 				</div>
 				<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
-					<div class='o-subs-card__read-more'>Read more</div>
+					<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<ul class="o-subs-card__copy-benefits">
 							<li>Access to FT's award-winning news on desktop, mobile and tablet</li>
@@ -37,7 +37,7 @@
 				</div>
 				<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
-					<div class='o-subs-card__read-more'>Read more</div>
+					<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<div class="o-subs-card__copy-preamble">Standard Digital benefits</div>
 						<ul class="o-subs-card__copy-benefits">
@@ -63,7 +63,7 @@
 				</div>
 				<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
-					<div class='o-subs-card__read-more'>Read more</div>
+					<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<div class="o-subs-card__copy-preamble">Standard Digital benefits, plus</div>
 						<ul class="o-subs-card__copy-benefits">
@@ -89,7 +89,7 @@
 				</div>
 				<div class="o-subs-card__copy-pitch">Access to FT.com on your desktop, mobile and tablet</div>
 				<div class="o-subs-card__expander">
-					<div class='o-subs-card__read-more'>Read more</div>
+					<button class='o-subs-card__read-more'></button>
 					<div class="o-subs-card__copy-details">
 						<div class="o-subs-card__copy-preamble">Standard Digital benefits, plus</div>
 						<ul class="o-subs-card__copy-benefits">

--- a/main.js
+++ b/main.js
@@ -7,4 +7,4 @@ const constructAll = function() {
 
 document.addEventListener('o.DOMContentLoaded', constructAll);
 
-export { SubsCard } from './src/js/subsCard';
+export { SubsCard } from './src/js/subsCard.js';

--- a/main.scss
+++ b/main.scss
@@ -4,6 +4,7 @@
 @import "o-typography/main";
 @import "o-expander/main";
 @import "o-spacing/main";
+@import "o-normalise/main";
 
 @import "src/scss/variables";
 @import "src/scss/mixins";

--- a/src/js/subsCard.js
+++ b/src/js/subsCard.js
@@ -21,10 +21,11 @@ class SubsCard {
 
 	setExpanders() {
 		const expander = this.rootEl.querySelector('.o-subs-card__expander');
+		const titleElem = this.rootEl.querySelector('.o-subs-card__copy-title');
 		const opts = {
 			shrinkTo: 'hidden',
-			expandedToggleText: 'Read less',
-			collapsedToggleText: 'Read more',
+			collapsedToggleText: titleElem ? `Read more <span class="o-subs-card-visually-hidden">about ${titleElem.textContent}</span>` : 'Read more',
+			expandedToggleText: titleElem ? `Read less <span class="o-subs-card-visually-hidden">about ${titleElem.textContent}</span>` : 'Read less',
 			toggleState: 'all',
 			selectors: {
 				toggle: '.o-subs-card__read-more',

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -3,6 +3,10 @@
 
 	text-align: center;
 
+	.o-subs-card-visually-hidden {
+		@include oNormaliseVisuallyHidden;
+	}
+
 	// https://github.com/philipwalton/flexbugs#flexbug-17 (for suport in ie 9/10)
 	@include oGridRespondTo(L) {
 		// 12px = the combined 6px padding either side.

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -27,7 +27,7 @@ function htmlCode () {
 				<div class="o-subs-card__copy-details">
 					Some content
 				</div>
-				<div class="o-subs-card__read-more"></div>
+				<button class="o-subs-card__read-more"></button>
 			</div>
 		</div>
 	</div>
@@ -45,7 +45,7 @@ function htmlCodeMulti () {
 					<div class="o-subs-card__copy-details">
 						Some content
 					</div>
-					<div class="o-subs-card__read-more"></div>
+					<button class="o-subs-card__read-more"></button>
 				</div>
 			</div>
 			<div class="o-subs-card" data-o-component="o-subs-card">
@@ -54,7 +54,7 @@ function htmlCodeMulti () {
 					<div class="o-subs-card__copy-details">
 						Some content
 					</div>
-					<div class="o-subs-card__read-more"></div>
+					<button class="o-subs-card__read-more"></button>
 				</div>
 			</div>
 		</div>

--- a/test/subsCard.test.js
+++ b/test/subsCard.test.js
@@ -63,8 +63,6 @@ describe("SubsCard", () => {
 		it('will all have matching top height', () => {
 			const matchHeightsSpy = sinon.spy(SubsCard, 'matchHeights');
 
-			console.log(matchHeightsSpy);
-
 			SubsCard.init();
 
 			proclaim.equal(matchHeightsSpy.called, true);


### PR DESCRIPTION
This builds on top of https://github.com/Financial-Times/o-subs-card/pull/87 with the changes applied in https://github.com/Financial-Times/o-subs-card/pull/85 excluding the parts which were for the npm version of o-subs-card

This was requested via Slack -- [financialtimes.slack.com/archives/C02FU5ARJ/p1636734189065900?thread_ts=1636628063.058600&cid=C02FU5ARJ](https://financialtimes.slack.com/archives/C02FU5ARJ/p1636734189065900?thread_ts=1636628063.058600&cid=C02FU5ARJ)

The plan is to not merge this, instead upon a successful review - we would tag the last commit of this PR with `v6.0.0-bower` for people to install it via bower